### PR TITLE
4章のrequirements.txtが古い？

### DIFF
--- a/chapter4/requirements.txt
+++ b/chapter4/requirements.txt
@@ -1,5 +1,6 @@
 boto3==1.34.87
-langchain==0.1.16
-langchain-aws==0.1.0
-langchain-community==0.0.33
+langchain==0.2.0
+langchain-aws==0.1.4
+langchain-community==0.2.0
 streamlit==1.33.0
+python-dateutil==2.8.2


### PR DESCRIPTION
P212 の `pip install` と requirements.txt がズレてるかもです。

```
ValidationError: 1 validation error for AmazonKnowledgeBasesRetriever __root__ Could not load credentials to authenticate with AWS client. Please check that credentials in the specified profile name are valid. (type=value_error)
```

というエラーが EC2 で出て、解決しようとしたときに、ライブラリが古そうということに気が付きました。
